### PR TITLE
feat: more accurate fst names

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -70,9 +70,8 @@ A mark that denotes where one meaningful sub-unit of a word is separated
 from a different, adjacent part of the same word.
 
 In Plains Cree, these marks are `<` and `>`. `<` occurs before the stem
-of a verb, separating person marking to the left of it, and `>` is
-placed immediately after the verb stem, separating the _other_ person
-marking.
+of a verbs and nouns and `>` is placed immediately after the noun or
+verb stem.
 
 For example,
 
@@ -83,13 +82,20 @@ Given `wâpam-` (stem of _wâpamêw_ (VTA)):
  - ki<wâpam>âw
 
 
+Note that the _exact_ location of morpheme boundaries is sometimes unclear
+due to morphophonological processes such as [sandhi]. Even in fuzzy
+cases, the FST will produce a morpheme boundary mark.
+
+[sandhi]: https://en.wikipedia.org/wiki/Sandhi
+
 ### strict
 
 Only produce or recognize text in a strict orthographical norm or
 standard. In the case of Plains Cree, this means texts that adheres to
 the [standard Roman orthography (SRO)][SRO].
 
-Note: The itwêwina database of dictionary heads is internally stored in SRO.
+Note: The itwêwina database of dictionary heads is internally stored in
+SRO, using circumflexes as the diacritic marker of vowel length.
 
 Examples:
 
@@ -106,6 +112,6 @@ Examples:
 
 (of an **analyzer**) it can take in forms that do not conform to the
 orthographical standard. We apply _spelling relaxation_ such that we can
-accept multiple possible spellings of words, and not require one exact
-spelling of words. The spelling relaxation is done through a manually
-maintained list of rules.
+accept multiple possible variant spellings of words, and will not
+require adhering exactly to one normative spelling of a word.. The
+spelling relaxation is done through a manually maintained list of rules.

--- a/src/README.md
+++ b/src/README.md
@@ -1,16 +1,110 @@
 How to use the alternative Makefile
 ===================================
 
+Type this:
+
     make -j -f quick.mk
 
-This will create:
+This will create _at least_ the following transducers (FSTs):
 
- - `crk-strict-analyzer.hfstol` -- reads Plains Cree wordforms and
-   outputs analyses. Wordforms must be written in _perfect_ SRO.
- - `crk-descriptive-analyzer.hfstol` -- reads Plains Cree wordforms, and
+ - `crk-strict-analyzer.hfstol` — reads Plains Cree wordforms and
+   outputs analyses. Wordforms must be written in _perfect_ [SRO].
+ - `crk-relaxed-analyzer.hfstol` — reads Plains Cree wordforms, and
    outputs possible analyses. Wordforms can be written with known
-   spelling variations, including long vowel relaxation.
- - `crk-normative-generator.hfstol` -- given a morphological analyses,
+   spelling variations, including long vowel relaxation. 😎🍹
+ - `crk-strict-generator.hfstol` — given a morphological analyses,
    produces Plains Cree wordforms in SRO.
- - `crk-normative-generator-with-morpheme-boundaries.hfstol` -- same as
+ - `crk-strict-generator-with-morpheme-boundaries.hfstol` same as
    above, but includes `<` and `>` to indicate morpheme boundaries
+
+Want even _more_ FSTs? FSTs intended for use in _itwêwina_, the online
+Cree dictionary? You got 'em! Type this:
+
+   make -j -f quick.mk dict
+
+Which will create two additional FSTs:
+
+ - `crk-strict-analyzer-for-dictionary.hfstol`
+ - `crk-relaxed-analyzer-for-dictionary.hfstol`
+
+These are the same as their counterparts, except they exclude some
+analyses that are unnecessary in a dictionary application.
+
+
+Mini-glossary
+-------------
+
+### `crk`
+
+The [ISO 639-3][] code for nêhiyawêwin, or Plains Cree.
+
+[ISO 639-3]: https://en.wikipedia.org/wiki/ISO_639-3
+
+### analyzer
+
+An FST that takes in a form in a language and attempts to produce one or
+more likely linguistic analyses.
+
+The inverse of a **generator**.
+
+### generator
+
+An FST that takes an analysis string from the language and attempts to
+produce a valid linguistic form.
+
+The inverse of an **analyzer**.
+
+### for dictionary
+
+Intended for use with itwêwina, or really any intelligent dictionary for
+Plains Cree.
+
+In practice, this means analyzers lack the `+Err/Frag` analyses and omit
+the `+Err/Orth` tag, since these offer little value to the dictionary
+(it's trying to match a lemma, after all!).
+
+### morpheme boundary
+
+A mark that denotes where one meaningful sub-unit of a word is separated
+from a different, adjacent part of the same word.
+
+In Plains Cree, these marks are `<` and `>`. `<` occurs before the stem
+of a verb, separating person marking to the left of it, and `>` is
+placed immediately after the stem, separating the _other_ person
+marking.
+
+For example,
+
+Given `wâpam` (stem of _wâpamêw_ (VTA)):
+
+ - <wâpam>êw
+ - ni<wâpam>âw
+ - ki<wâpam>âw
+
+
+### strict
+
+Only produce or recognize text in a strict orthographical norm or
+standard. In the case of Plains Cree, this means texts that adheres to
+the [standard Roman orthography (SRO)][SRO].
+
+Note: The itwêwina database of dictionary heads is internally stored in SRO.
+
+Examples:
+
+| Non-SRO    | SRO                      | Syllabics   |
+|------------|--------------------------|-------------|
+| atchakosuk | acâhkosak                | ᐊᐦᒐᐦᑯᓴᐠ     |
+| neeyuh     | niya                     | ᓂᔭ          |
+| nagee      | nakî                     | ᓇᑮ          |
+| ewapamat   | ê-wâpamat _or_ ê-wâpamât | ᐁ ᐚᐸᒪᐟ      |
+
+[SRO]: https://creeliteracy.org/wp-content/uploads/2016/01/htsiic-covers-nocontacts.pdf
+
+### relaxed
+
+(of an **analyzer**) it can take in forms that are not necessarily in
+the strict internal. We apply _spelling relaxation_ such that we can
+accept multiple possible spellings of words, and not require one exact
+spelling of words. The spelling relaxation is done through a manually
+maintained list of rules.

--- a/src/README.md
+++ b/src/README.md
@@ -20,7 +20,7 @@ This will create _at least_ the following transducers (FSTs):
 Want even _more_ FSTs? FSTs intended for use in _itwêwina_, the online
 Cree dictionary? You got 'em! Type this:
 
-   make -j -f quick.mk dict
+    make -j -f quick.mk dict
 
 Which will create two additional FSTs:
 
@@ -28,7 +28,8 @@ Which will create two additional FSTs:
  - `crk-relaxed-analyzer-for-dictionary.hfstol`
 
 These are the same as their counterparts, except they exclude some
-analyses that are unnecessary in a dictionary application.
+analyses that are unnecessary in a dictionary application (namely,
+_itwêwina_).
 
 
 Mini-glossary
@@ -56,10 +57,10 @@ The inverse of an **analyzer**.
 
 ### for dictionary
 
-Intended for use with itwêwina, or really any intelligent dictionary for
-Plains Cree.
+(of an FST) intended for use with itwêwina, or really any intelligent
+dictionary for Plains Cree.
 
-In practice, this means analyzers lack the `+Err/Frag` analyses and omit
+In practice, this means analyzers lack all `+Err/Frag` analyses and omit
 the `+Err/Orth` tag, since these offer little value to the dictionary
 (it's trying to match a lemma, after all!).
 
@@ -70,12 +71,12 @@ from a different, adjacent part of the same word.
 
 In Plains Cree, these marks are `<` and `>`. `<` occurs before the stem
 of a verb, separating person marking to the left of it, and `>` is
-placed immediately after the stem, separating the _other_ person
+placed immediately after the verb stem, separating the _other_ person
 marking.
 
 For example,
 
-Given `wâpam` (stem of _wâpamêw_ (VTA)):
+Given `wâpam-` (stem of _wâpamêw_ (VTA)):
 
  - <wâpam>êw
  - ni<wâpam>âw
@@ -103,8 +104,8 @@ Examples:
 
 ### relaxed
 
-(of an **analyzer**) it can take in forms that are not necessarily in
-the strict internal. We apply _spelling relaxation_ such that we can
+(of an **analyzer**) it can take in forms that do not conform to the
+orthographical standard. We apply _spelling relaxation_ such that we can
 accept multiple possible spellings of words, and not require one exact
 spelling of words. The spelling relaxation is done through a manually
 maintained list of rules.

--- a/src/morphological-fst-rules.mk
+++ b/src/morphological-fst-rules.mk
@@ -59,10 +59,9 @@ crk-strict-generator.hfst: crk-strict-analyzer.hfst
 	-@echo "$(_EMPH)Inverting the analyzer to create the strict generator.$(_RESET)"
 	hfst-invert $^ -o $@
 
-
 crk-relaxed-analyzer.hfst: crk-strict-analyzer.hfst crk-orth.hfst
 	-@echo "$(_EMPH)Composing spelling relaxation transducer with normative analyzer transducer to create descriptive analyzer.$(_RESET)"
-	hfst-invert -i $(word 1, $^) | hfst-compose --harmonize-flags -1 - -2 $(word 2, $^) | hfst-minimize - | hfst-invert - -o $@
+	hfst-invert -i $(word 1, $^) | hfst-compose --harmonize-flags -1 - -2 $(word 2, $^) | hfst-minimize | hfst-invert - -o $@
 
 remove-morpheme-boundary-filter.hfst:
 	-@echo "$(_EMPH)Compiling filter to remove morpheme boundaries.$(_RESET)"

--- a/src/quick.mk
+++ b/src/quick.mk
@@ -42,7 +42,7 @@ all: $(FSTs)
 dict: $(DICTFSTs)
 
 clean:
-	$(RM) $(FSTs) $(FSTS_UNDER_TEST) $(FOMAFSTs)
+	$(RM) $(FSTs) $(FSTS_UNDER_TEST) $(FOMAFSTs) $(wildcard *.hfst)
 
 test: $(FSTS_UNDER_TEST)
 	fsttest
@@ -52,7 +52,7 @@ test: $(FSTS_UNDER_TEST)
 
 ############################## Specific targets ##############################
 
-fsts.zip: $(FSTs) $(FOMAFSTs)
+fsts.zip: $(DICTFSTs) $(FOMAFSTs)
 	zip $@ $^
 
 

--- a/src/quick.mk
+++ b/src/quick.mk
@@ -32,7 +32,7 @@ DICTFSTs = $(FSTs) \
 FOMAFSTs = $(FSTs:.hfstol=.fomabin)
 # fsttest REQUIRES fomabins. Place any FSTs that you want to test here with
 # the .fomabin extension:
-FSTS_UNDER_TEST = $(FOMAFSTs) crk-lexc-dict.fomabin ./crk-normative-generator-with-morpheme-boundaries.fomabin
+FSTS_UNDER_TEST = $(FOMAFSTs) crk-lexc-dict.fomabin crk-strict-generator-with-morpheme-boundaries.fomabin
 
 
 ################################## Commands ##################################

--- a/src/quick.mk
+++ b/src/quick.mk
@@ -35,8 +35,13 @@ all: $(FSTs)
 fsts.zip: $(FSTs) $(FOMAFSTs)
 	zip $@ $^
 
+clean:
+	$(RM) $(FSTs) $(FSTS_UNDER_TEST) $(FOMAFSTs)
+
 test: $(FSTS_UNDER_TEST) 
 	fsttest
+
+.PHONY: all clean test
 
 include morphological-fst-sources.mk
 include morphological-fst-rules.mk

--- a/src/quick.mk
+++ b/src/quick.mk
@@ -20,10 +20,14 @@
 #
 # 	make -j -f quick.mk
 
-FSTs = crk-descriptive-analyzer.hfstol \
-	crk-normative-generator.hfstol \
-	crk-strict-analyzer.hfstol \
-	crk-normative-generator-with-morpheme-boundaries.hfstol
+FSTs = crk-strict-analyzer.hfstol \
+       crk-relaxed-analyzer.hfstol \
+       crk-strict-generator.hfstol \
+       crk-strict-generator-with-morpheme-boundaries.hfstol
+
+DICTFSTs = $(FSTs) \
+           crk-strict-analyzer-for-dictionary.hfstol \
+           crk-relaxed-analyzer-for-dictionary.hfstol
 
 FOMAFSTs = $(FSTs:.hfstol=.fomabin)
 # fsttest REQUIRES fomabins. Place any FSTs that you want to test here with
@@ -34,6 +38,8 @@ FSTS_UNDER_TEST = $(FOMAFSTs) crk-lexc-dict.fomabin ./crk-normative-generator-wi
 ################################## Commands ##################################
 
 all: $(FSTs)
+
+dict: $(DICTFSTs)
 
 clean:
 	$(RM) $(FSTs) $(FSTS_UNDER_TEST) $(FOMAFSTs)

--- a/src/quick.mk
+++ b/src/quick.mk
@@ -30,18 +30,26 @@ FOMAFSTs = $(FSTs:.hfstol=.fomabin)
 # the .fomabin extension:
 FSTS_UNDER_TEST = $(FOMAFSTs) crk-lexc-dict.fomabin ./crk-normative-generator-with-morpheme-boundaries.fomabin
 
-all: $(FSTs)
 
-fsts.zip: $(FSTs) $(FOMAFSTs)
-	zip $@ $^
+################################## Commands ##################################
+
+all: $(FSTs)
 
 clean:
 	$(RM) $(FSTs) $(FSTS_UNDER_TEST) $(FOMAFSTs)
 
-test: $(FSTS_UNDER_TEST) 
+test: $(FSTS_UNDER_TEST)
 	fsttest
 
 .PHONY: all clean test
 
+
+############################## Specific targets ##############################
+
+fsts.zip: $(FSTs) $(FOMAFSTs)
+	zip $@ $^
+
+
+# The rest is defined in these two files
 include morphological-fst-sources.mk
 include morphological-fst-rules.mk

--- a/src/tests/test_crk_normative_generator_with_morpheme_boundaries.toml
+++ b/src/tests/test_crk_normative_generator_with_morpheme_boundaries.toml
@@ -1,5 +1,5 @@
 [fst]
-fomabin = "crk-normative-generator-with-morpheme-boundaries.fomabin"
+fomabin = "crk-strict-generator-with-morpheme-boundaries.fomabin"
 
 [[tests]]
 lower = "nipâw+V+AI+Ind+1Sg"

--- a/src/tests/test_regressions.toml
+++ b/src/tests/test_regressions.toml
@@ -1,5 +1,5 @@
 [fst]
-fomabin = "crk-normative-generator.fomabin"
+fomabin = "crk-strict-generator.fomabin"
 
 # See: https://github.com/giellalt/lang-crk/issues/14
 [[tests]]

--- a/src/tests/test_spell_relax.toml
+++ b/src/tests/test_spell_relax.toml
@@ -1,5 +1,5 @@
 [fst]
-fomabin = "crk-descriptive-analyzer.fomabin"
+fomabin = "crk-relaxed-analyzer.fomabin"
 
 [[tests]]
 lower = "tansi"


### PR DESCRIPTION
Work/life balance? What work/life balance! 😜

I have renamed the FSTs, and now here are the ones we'll use:

 - `crk-strict-analyzer`: analyzer, no spelling relaxation
 - `crk-strict-generator-with-morpheme-boundaries`: given an analyses, produces forms with `<` and `>` word boundaries!
 - `crk-strict-generator`: same as above, the morpheme boundaries are omitted
- `crk-relaxed-analyzer`: analyzer with spelling relaxation

And some new FSTs!

 - `crk-strict-analyzer-for-dictionary`: analyzer lacking `+Err/Frag` forms
 - `crk-relaxed-analyzer-for-dictionary`: analyzer lacking `+Err/Frag` forms and omitting the `+Err/Orth` tag from analyses


This is the series of commands issued when you run `make -f quick.mk dicts`:

```sh
echo "Concatenating LEXC files."
cat fst/root.lexc fst/affixes/noun_affixes.lexc fst/affixes/verb_affixes.lexc fst/stems/noun_stems.lexc fst/stems/numerals.lexc fst/stems/particles.lexc fst/stems/pronouns.lexc fst/stems/verb_stems.lexc fst/stems/derivation_stems.lexc fst/stems/non_standard.lexc fst/stems/noun_vocatives.lexc > crk-dict.lexc
echo "Compiling LEXC code."
hfst-lexc --format=openfst-tropical -o crk-lexc-dict.hfst crk-dict.lexc
echo "Compiling xfscript code for morphophonology."
echo "(this one takes a while... ☕️)"
hfst-xfst --pipe-mode --verbose --format=openfst-tropical	-e "source fst/phonology.xfscript" -E "save stack crk-phon.hfst"
echo "Composing lexicon with morphophonology."
hfst-compose --harmonize-flags -1 crk-lexc-dict.hfst -2 crk-phon.hfst | hfst-minimize - -o crk-strict-generator-with-morpheme-boundaries.hfst
echo "Compiling filter to remove morpheme boundaries."
echo '%> -> 0, %< -> 0;' | hfst-regexp2fst --verbose --semicolon -o remove-morpheme-boundary-filter.hfst
echo "Removing morpheme boundaries to create strict analyzer."
hfst-compose --harmonize-flags -1 crk-strict-generator-with-morpheme-boundaries.hfst -2 remove-morpheme-boundary-filter.hfst | hfst-invert | hfst-minimize -o crk-strict-analyzer.hfst
hfst-fst2fst --optimized-lookup-unweighted -i crk-strict-analyzer.hfst -o crk-strict-analyzer.hfstol
echo "Compiling regular expression implementing spelling-relaxation."
hfst-regexp2fst --verbose --semicolon orthography/spellrelax.regex -o crk-orth.hfst
echo "Composing spelling relaxation transducer with normative analyzer transducer to create descriptive analyzer."
hfst-invert -i crk-strict-analyzer.hfst | hfst-compose --harmonize-flags -1 - -2 crk-orth.hfst | hfst-minimize | hfst-invert - -o crk-relaxed-analyzer.hfst
hfst-fst2fst --optimized-lookup-unweighted -i crk-relaxed-analyzer.hfst -o crk-relaxed-analyzer.hfstol
echo "Inverting the analyzer to create the strict generator."
hfst-invert crk-strict-analyzer.hfst -o crk-strict-generator.hfst
hfst-fst2fst --optimized-lookup-unweighted -i crk-strict-generator.hfst -o crk-strict-generator.hfstol
hfst-fst2fst --optimized-lookup-unweighted -i crk-strict-generator-with-morpheme-boundaries.hfst -o crk-strict-generator-with-morpheme-boundaries.hfstol
echo "Compiling filter to remove +Err/Frag analyses and omit +Err/Orth from analyses"
echo '~[ $[ "+Err/Frag" ] ] .o. [ "+Err/Orth" -> 0 ] ; ' | hfst-regexp2fst --verbose --semicolon - -o crk-dict-filter.hfst
echo "Creating dictionary version of crk-strict-analyzer.hfst"
hfst-compose  --harmonize-flags -1 crk-strict-analyzer.hfst -2 crk-dict-filter.hfst |\
		hfst-minimize - -o crk-strict-analyzer-for-dictionary.hfst
hfst-fst2fst --optimized-lookup-unweighted -i crk-strict-analyzer-for-dictionary.hfst -o crk-strict-analyzer-for-dictionary.hfstol
echo "Creating dictionary version of crk-relaxed-analyzer.hfst"
hfst-compose  --harmonize-flags -1 crk-relaxed-analyzer.hfst -2 crk-dict-filter.hfst |\
		hfst-minimize - -o crk-relaxed-analyzer-for-dictionary.hfst
hfst-fst2fst --optimized-lookup-unweighted -i crk-relaxed-analyzer-for-dictionary.hfst -o crk-relaxed-analyzer-for-dictionary.hfstol
```


Fixes #17 
Fixes #18 